### PR TITLE
Add support for influx escaping rules

### DIFF
--- a/src/dp_decoder.erl
+++ b/src/dp_decoder.erl
@@ -4,7 +4,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
--export([recombine_tags/1, to_number/1, protocol/1, parse/2]).
+-export([recombine_tags/1, to_number/1, to_time/1, protocol/1, parse/2]).
 -export_type([metric/0, protocol/0]).
 
 -type metric() :: #{
@@ -33,6 +33,16 @@ to_number(X) ->
         error:badarg ->
             binary_to_integer(X)
     end.
+
+%% @doc Normalizes a timestamp to second precision.  For higher precision
+%% timestamps, this is lossy. Protocols such as Influx can send timestamps in
+%% one of [n,u,ms,s,m,h].
+to_time(Time) when is_binary(Time) ->
+    N = to_number(Time),
+    SecondsPrecision = 9,
+    Log = trunc(math:log10(N)),
+    Exp = math:pow(10, Log - SecondsPrecision),
+    round(N / Exp).
 
 -spec parse(Decoder::module(), In::binary()) ->
                    {ok, [dp_decoder:metric()]} | {error, term()} | undefined.

--- a/src/dp_decoder.erl
+++ b/src/dp_decoder.erl
@@ -34,6 +34,8 @@ to_number(X) ->
             binary_to_integer(X)
     end.
 
+to_time(<<>>) ->
+    erlang:system_time(seconds);
 %% @doc Normalizes a timestamp to second precision.  For higher precision
 %% timestamps, this is lossy. Protocols such as Influx can send timestamps in
 %% one of [n,u,ms,s,m,h].

--- a/src/dp_influx.erl
+++ b/src/dp_influx.erl
@@ -52,8 +52,8 @@ parse_tag(<<C, R/binary>>, K) ->
     parse_tag(R, <<K/binary, C>>).
 
 %% Time format values such as \" 0:00 \" are ignored
-parse_metrics(<<"\" ", R/binary>>, _Metric, Metrics, M) ->
-    R0 = consume(R, $"),
+parse_metrics(<<$", R/binary>>, _Metric, Metrics, M) ->
+    R0 = consume_str(R),
     parse_metrics(R0, <<>>, Metrics, M);
 parse_metrics(<<" ", TimeS/binary>>, Metric, Metrics,
               M = #{key := [K1 | Ks], metric := Ms}) ->
@@ -87,13 +87,13 @@ parse_value(<<>>, V) ->
 parse_value(<<C, R/binary>>, V) ->
     parse_value(R, <<V/binary, C>>).
 
-%% Consume from the binary until it's empty or a Sentinel is matched
-consume(<<>>, _Sentinel) ->
+%% Consume from the binary until the end of the string is encountered
+consume_str(<<>>) ->
     <<>>;
-consume(<<_C, R/binary>>, Sentinel) when _C =:= Sentinel ->
+consume_str(<<$", R/binary>>) ->
     R;
-consume(<<_C, R/binary>>, Sentinel) ->
-    consume(R, Sentinel).
+consume_str(<<_C, R/binary>>) ->
+    consume_str(R).
 
 -spec protocol() -> dp_line_proto.
 protocol() ->

--- a/src/dp_influx.erl
+++ b/src/dp_influx.erl
@@ -52,8 +52,9 @@ parse_tag(<<C, R/binary>>, K) ->
     parse_tag(R, <<K/binary, C>>).
 
 %% Time format values such as \" 0:00 \" are ignored
-parse_metrics(<<"\" ", _F:4/binary, "\"", R/binary>>, _Metric, Metrics, M) ->
-    parse_metrics(R, <<>>, Metrics, M);
+parse_metrics(<<"\" ", R/binary>>, _Metric, Metrics, M) ->
+    R0 = consume(R, $"),
+    parse_metrics(R0, <<>>, Metrics, M);
 parse_metrics(<<" ", TimeS/binary>>, Metric, Metrics,
               M = #{key := [K1 | Ks], metric := Ms}) ->
 
@@ -86,7 +87,13 @@ parse_value(<<>>, V) ->
 parse_value(<<C, R/binary>>, V) ->
     parse_value(R, <<V/binary, C>>).
 
-
+%% Consume from the binary until it's empty or a Sentinel is matched
+consume(<<>>, _Sentinel) ->
+    <<>>;
+consume(<<_C, R/binary>>, Sentinel) when _C =:= Sentinel ->
+    R;
+consume(<<_C, R/binary>>, Sentinel) ->
+    consume(R, Sentinel).
 
 -spec protocol() -> dp_line_proto.
 protocol() ->

--- a/src/dp_influx.erl
+++ b/src/dp_influx.erl
@@ -133,7 +133,7 @@ float_test() ->
 
 telegraf_test() ->
     In = <<"system,host=vagrant "
-           "uptime=18i,uptime_format=\" 0:00\" "
+           "uptime=18,uptime_format=\" 0:00\" "
            "1472723170">>,
     Time = 1472723170,
     Value = 18,

--- a/src/dp_influx.erl
+++ b/src/dp_influx.erl
@@ -7,12 +7,24 @@
 
 -export([protocol/0, parse/1]).
 
--spec parse(In::binary()) ->
-                   {ok, [dp_decoder:metric()]} | undefined.
 -define(POS_INF, 42.0e+100).
 -define(NEG_INF, -42.0e+100).
 -define(NAN, 0).
+-define(BOOL_TRUE, 1).
+-define(BOOL_FALSE, 0).
+
+%% @doc
+%% Parses the Influx line protocol. The syntax for the Influx line protocol is:
+%%  measurement[,tag_key1=tag_value1...] field_key=field_value[,...] [ts]
+%%
+%% More information on the protocol and escaping rules can be found online:
+%% https://docs.influxdata.com/influxdb/v0.13/write_protocols/write_syntax
+%% @end
+-spec parse(In::binary()) ->
+                   {ok, [dp_decoder:metric()]} | undefined.
 parse(<<>>) ->
+    undefined;
+parse(<<"#", _/binary>>) ->
     undefined;
 parse(In) ->
     M = #{
@@ -22,15 +34,25 @@ parse(In) ->
       time => 0,
       value => 0
      },
-    parse_metric(In, <<>>, M).
+    parse_measurement(In, <<>>, M).
 
-parse_metric(<<",", R/binary>>, Metric, M) ->
-    M1 = M#{key := [Metric],
-            metric := [Metric]},
+%% Measurements require escaping for commas and whitespace
+parse_measurement(<<$\\, $,, R/binary>>, Measure, M) ->
+    parse_measurement(R, <<Measure/binary, ",">>, M);
+parse_measurement(<<"\\ ", R/binary>>, Measure, M) ->
+    parse_measurement(R, <<Measure/binary, " ">>, M);
+parse_measurement(<<",", R/binary>>, Measure, M) ->
+    M1 = M#{key := [Measure],
+            metric := [Measure]},
     parse_tags(R, <<>>, M1);
-parse_metric(<<C, R/binary>>, Metric, M) ->
-    parse_metric(R, <<Metric/binary, C>>, M).
+parse_measurement(<<C, R/binary>>, Measure, M) ->
+    parse_measurement(R, <<Measure/binary, C>>, M).
 
+%% Tag keys require escaping for commas, whitespace and equals
+parse_tags(<<$\\, $,, R/binary>>, Tag, M) ->
+    parse_tags(R, <<Tag/binary, ",">>, M);
+parse_tags(<<"\\ ", R/binary>>, Tag, M) ->
+    parse_tags(R, <<Tag/binary, " ">>, M);
 parse_tags(<<" ", R/binary>>, Tag, M = #{key := Ks, tags := Tags}) ->
     {K, V} = parse_tag(Tag, <<>>),
     Tags1 = lists:sort([{<<"">>, K, V} | Tags]),
@@ -46,54 +68,92 @@ parse_tags(<<",", R/binary>>, Tag, M = #{key := Ks, tags := Tags}) ->
 parse_tags(<<C, R/binary>>, Tag, M) ->
     parse_tags(R, <<Tag/binary, C>>, M).
 
+parse_tag(<<$\\, $=, R/binary>>, K) ->
+    parse_tag(R, <<K/binary, $=>>);
 parse_tag(<<"=", V/binary>>, K) ->
     {K, V};
 parse_tag(<<C, R/binary>>, K) ->
     parse_tag(R, <<K/binary, C>>).
 
-%% Time format values such as \" 0:00 \" are ignored
-parse_metrics(<<$", R/binary>>, _Metric, Metrics, M) ->
-    R0 = consume_str(R),
-    parse_metrics(R0, <<>>, Metrics, M);
+%% Field keys require escaping for commas, whitespace and equals. Fields may
+%% have 'boolean', 'string', 'int' or 'float' values. Fields with 'string'
+%% values are re-classified as tags
+parse_metrics(<<$", R/binary>>, Metric, Metrics,
+              M = #{key := Ks, tags := Tags}) ->
+    {V, R0} = parse_str_value(R, <<>>),
+    {K, V}  = parse_tag(<<Metric/binary, V/binary>>, <<>>),
+    Tags1 = lists:sort([{<<"">>, K, V} | Tags]),
+    M1 = M#{key := Ks ++ dp_decoder:recombine_tags(Tags1),
+            tags := Tags1},
+    parse_metrics(R0, <<>>, Metrics, M1);
+parse_metrics(<<$\\, $,, R/binary>>, Metric, Metrics, M) ->
+    parse_metrics(R, <<Metric/binary, ",">>, Metrics, M);
+parse_metrics(<<"\\ ", R/binary>>, Metric, Metrics, M) ->
+    parse_metrics(R, <<Metric/binary, " ">>, Metrics, M);
 parse_metrics(<<" ", TimeS/binary>>, Metric, Metrics,
-              M = #{key := [K1 | Ks], metric := Ms}) ->
-
-    Metrics1 = case byte_size(Metric) of
-                   Size when Size > 0 ->
-                       [parse_metric(Metric, <<>>) | Metrics];
-                   0 ->
-                       Metrics
-               end,
+              M = #{key := [K1 | Ks], metric := Ms}) when Metric =/= <<>> ->
+    Metrics1 = [parse_metric(Metric, <<>>) | Metrics],
     Time = dp_decoder:to_time(TimeS),
     M1 = M#{time := Time },
     {ok, [M1#{value := V, metric := Ms ++ [K],
               key := [K1, K | Ks]} || {K, V} <- Metrics1]};
-parse_metrics(<<",", R/binary>>, Metric, Metrics, M) ->
+parse_metrics(<<",", R/binary>>, Metric, Metrics, M) when Metric =/= <<>> ->
     parse_metrics(R, <<>>, [parse_metric(Metric, <<>>) | Metrics], M);
 parse_metrics(<<C, R/binary>>, Metric, Metrics, M) ->
     parse_metrics(R, <<Metric/binary, C>>, Metrics, M).
 
+parse_metric(<<$\\, $=, R/binary>>, K) ->
+    parse_metric(R, <<K/binary, "=">>);
 parse_metric(<<"=", V/binary>>, K) ->
     {K, parse_value(V, <<>>)};
 parse_metric(<<C, R/binary>>, K) ->
     parse_metric(R, <<K/binary, C>>).
 
+%% Boolean true may be one of ['t', 'T', 'true', 'True', 'TRUE']
+parse_value(<<"t">>, _V) ->
+    ?BOOL_TRUE;
+parse_value(<<"T">>, _V) ->
+    ?BOOL_TRUE;
+parse_value(<<"true">>, _V) ->
+    ?BOOL_TRUE;
+parse_value(<<"True">>, _V) ->
+    ?BOOL_TRUE;
+parse_value(<<"TRUE">>, _V) ->
+    ?BOOL_TRUE;
+
+%% Boolean false may be one of ['f', 'F', 'false', 'False', 'FALSE']
+parse_value(<<"f">>, _V) ->
+    ?BOOL_FALSE;
+parse_value(<<"F">>, _V) ->
+    ?BOOL_FALSE;
+parse_value(<<"false">>, _V) ->
+    ?BOOL_FALSE;
+parse_value(<<"False">>, _V) ->
+    ?BOOL_FALSE;
+parse_value(<<"FALSE">>, _V) ->
+    ?BOOL_FALSE;
+
+%% Integers are suffixed with 'i'
 parse_value(<<"i">>, V) ->
     binary_to_integer(V);
-%% Strictly speaking, this would be a float.  However, some influx producers
-%% are less conformant to the line spec.
+
+%% Floats do not need a suffix
 parse_value(<<>>, V) ->
+    %% This tolerates integers with no 'i' suffix
     dp_decoder:to_number(V);
+
 parse_value(<<C, R/binary>>, V) ->
     parse_value(R, <<V/binary, C>>).
 
-%% Consume from the binary until the end of the string is encountered
-consume_str(<<>>) ->
-    <<>>;
-consume_str(<<$", R/binary>>) ->
-    R;
-consume_str(<<_C, R/binary>>) ->
-    consume_str(R).
+%% String field values only require '"' to be escaped
+parse_str_value(<<>>, V) ->
+    {V, <<>>};
+parse_str_value(<<$\\, $", R/binary>>, V) ->
+    parse_str_value(R, <<V/binary, $">>);
+parse_str_value(<<$", R/binary>>, V) ->
+    {V, R};
+parse_str_value(<<C, R/binary>>, V) ->
+    parse_str_value(R, <<V/binary, C>>).
 
 -spec protocol() -> dp_line_proto.
 protocol() ->
@@ -138,20 +198,111 @@ float_test() ->
     ?assertEqual(Metric, RMetric),
     ?assertEqual(Value, RValue).
 
-telegraf_test() ->
-    In = <<"system,host=vagrant "
-           "uptime=18,uptime_format=\" 0:00\" "
-           "1472723170">>,
-    Time = 1472723170,
-    Value = 18,
-    Metric = [<<"system">>, <<"uptime">>],
-    Tags = [{<<>>, <<"host">>, <<"vagrant">>}],
-    [#{tags := RTags, time := RTime, value := RValue, metric := RMetric}]
+bool_true_test() ->
+    In = <<"cpu,hostname=host_0 "
+           "t1=T,t2=t,t3=true,t4=True,t5=TRUE "
+           "1451606400000000000">>,
+    Time = 1451606400,
+    Value = 1,
+    Metric1 = [<<"cpu">>, <<"t5">>],
+    Metric2 = [<<"cpu">>, <<"t4">>],
+    Metric3 = [<<"cpu">>, <<"t3">>],
+    Metric4 = [<<"cpu">>, <<"t2">>],
+    Metric5 = [<<"cpu">>, <<"t1">>],
+    Tags = [{<<>>, <<"hostname">>, <<"host_0">>}],
+    [#{tags := Tags, time := Time, value := RValue1, metric := RMetric1},
+     #{tags := Tags, time := Time, value := RValue2, metric := RMetric2},
+     #{tags := Tags, time := Time, value := RValue3, metric := RMetric3},
+     #{tags := Tags, time := Time, value := RValue4, metric := RMetric4},
+     #{tags := Tags, time := Time, value := RValue5, metric := RMetric5}]
         = p(In),
-    ?assertEqual(Tags, RTags),
-    ?assertEqual(Time, RTime),
-    ?assertEqual(Metric, RMetric),
-    ?assertEqual(Value, RValue).
+    ?assertEqual(Value,   RValue1),
+    ?assertEqual(Metric1, RMetric1),
+    ?assertEqual(Value,   RValue2),
+    ?assertEqual(Metric2, RMetric2),
+    ?assertEqual(Value,   RValue3),
+    ?assertEqual(Metric3, RMetric3),
+    ?assertEqual(Value,   RValue4),
+    ?assertEqual(Metric4, RMetric4),
+    ?assertEqual(Value,   RValue5),
+    ?assertEqual(Metric5, RMetric5).
+
+bool_false_test() ->
+    In = <<"cpu,hostname=host_0 "
+           "t1=F,t2=f,t3=false,t4=False,t5=FALSE "
+           "1451606400000000000">>,
+    Time = 1451606400,
+    Value = 0,
+    Metric1 = [<<"cpu">>, <<"t5">>],
+    Metric2 = [<<"cpu">>, <<"t4">>],
+    Metric3 = [<<"cpu">>, <<"t3">>],
+    Metric4 = [<<"cpu">>, <<"t2">>],
+    Metric5 = [<<"cpu">>, <<"t1">>],
+    Tags = [{<<>>, <<"hostname">>, <<"host_0">>}],
+    [#{tags := Tags, time := Time, value := RValue1, metric := RMetric1},
+     #{tags := Tags, time := Time, value := RValue2, metric := RMetric2},
+     #{tags := Tags, time := Time, value := RValue3, metric := RMetric3},
+     #{tags := Tags, time := Time, value := RValue4, metric := RMetric4},
+     #{tags := Tags, time := Time, value := RValue5, metric := RMetric5}]
+        = p(In),
+    ?assertEqual(Value,   RValue1),
+    ?assertEqual(Metric1, RMetric1),
+    ?assertEqual(Value,   RValue2),
+    ?assertEqual(Metric2, RMetric2),
+    ?assertEqual(Value,   RValue3),
+    ?assertEqual(Metric3, RMetric3),
+    ?assertEqual(Value,   RValue4),
+    ?assertEqual(Metric4, RMetric4),
+    ?assertEqual(Value,   RValue5),
+    ?assertEqual(Metric5, RMetric5).
+
+escaped_measurement_test() ->
+    In = <<"\\,c\\ pu=,hostname=host_0 "
+           "usage_user=58.1317132304976170 "
+           "1451606400000000000">>,
+    Metric = [<<",c pu=">>, <<"usage_user">>],
+    [#{tags := _RTags, time := _RTime, value := _RValue, metric := RMetric}]
+        = p(In),
+    ?assertEqual(Metric, RMetric).
+
+escaped_tag_keys_test() ->
+    In = <<"cpu,h\\,ost\\ n\\=ame=host_0,\\ =east "
+           "usage_user=58.1317132304976170 "
+           "1451606400000000000">>,
+    Tags = [{<<>>, <<" ">>, <<"east">>},
+            {<<>>, <<"h,ost n=ame">>, <<"host_0">>}],
+    [#{tags := RTags, time := _RTime, value := _RValue, metric := _RMetric}]
+        = p(In),
+    ?assertEqual(Tags, RTags).
+
+escaped_fields_test() ->
+    In = <<"cpu,hostname=host_0 "
+           "us\\,a\\ge\\ u\\=ser=58.1317132304976170 "
+           "1451606400000000000">>,
+    Metric = [<<"cpu">>, <<"us,a\\ge u=ser">>],
+    [#{tags := _RTags, time := _RTime, value := _RValue, metric := RMetric}]
+        = p(In),
+    ?assertEqual(Metric, RMetric).
+
+escaped_field_value_test() ->
+    In = <<"cpu,hostname=host_0 "
+           "usage_user=\"J\\\"o, = h\\n\",io_time=3i "
+           "1451606400000000000">>,
+    Tags = [{<<>>, <<"hostname">>, <<"host_0">>},
+            {<<>>, <<"usage_user">>, <<"J\"o, = h\\n">>}],
+    [#{tags := RTags, time := _RTime, value := _RValue, metric := _RMetric}] = p(In),
+    ?assertEqual(Tags, RTags).
+
+empty_timestamp_test() ->
+    In = <<"cpu,hostname=host_0 "
+           "usage_user=3i ">>,
+    Time = erlang:system_time(seconds),
+    Value = 3,
+    Metric = [<<"cpu">>, <<"usage_user">>],
+    Tags = [{<<>>, <<"hostname">>, <<"host_0">>}],
+    [#{tags := _RTags, time := RTime, value := _RValue, metric := _RMetric}]
+        = p(In),
+    ?assert(Time =< RTime).
 
 multi_test() ->
     In = <<"cpu,hostname=host_0,rack=67,os=Ubuntu16.1 "


### PR DESCRIPTION
Escaping rules for line format are here:https://docs.influxdata.com/influxdb/v0.13/write_protocols/write_syntax/
